### PR TITLE
Fix/support 11629

### DIFF
--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -4,6 +4,7 @@ on:
     branches:
       - 'feature/*'
       - 'bug/*'
+      - 'fix/*'
     tags:
       - '*' # Skip the workflow on the main branch without tags
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -23,7 +23,7 @@ RUN pip install -r /code/requirements.txt
 WORKDIR /code/
 
 # set switch that enables correct JVM memory allocation in containers
-ENV JAVA_OPTS="-XX:+UseContainerSupport -Xmx512m"
+ENV JAVA_OPTS="-XX:+UseContainerSupport -Xmx1024m"
 
 
 CMD ["python", "-u", "/code/src/component.py"]

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,3 +3,4 @@ tabula-py==2.9.3
 mock==4.0.3
 freezegun==1.1.0
 PyPDF2==1.26.0
+jpype1==1.5.1

--- a/src/kb_parser/parser.py
+++ b/src/kb_parser/parser.py
@@ -150,7 +150,7 @@ def _load_single_page_section_from_template(file_path: str, section_name: str,
                                            java_options=JAVA_OPTIONS,
                                            stream=stream,
                                            pages=page_nr,
-                                           silent=True,
+                                           force_subprocess=True,
                                            **kwargs)[0]
         return df.to_dict('records')
     except KeyError:
@@ -359,7 +359,6 @@ def _get_full_statement_rows(file_path: str) -> Iterator[Iterator[dict]]:
                                   stream=True,
                                   pandas_options=PANDAS_OPTIONS,
                                   java_options=JAVA_OPTIONS,
-                                  silent=True,
                                   force_subprocess=True,
                                   pages=f'{start_range}-{end_range}'):
             yield (row for row in df.to_dict('records'))

--- a/src/kb_parser/parser.py
+++ b/src/kb_parser/parser.py
@@ -12,12 +12,12 @@ from typing import List, Iterator, Tuple, Union, Callable
 import PyPDF2
 import tabula
 
-MAX_CHUNK_SIZE = 1000
+MAX_CHUNK_SIZE = 500
 
 PANDAS_OPTIONS = {'dtype': str}
 
 # Limit the memory for docker execution / requires JAVA 11
-JAVA_OPTIONS = '-Xmx768m -Xms768m'
+JAVA_OPTIONS = ['-Xmx900m', '-Xms512m']
 
 # DATA_COLUMN_BOUNDARIES = [42.16, 223.0, 416.0, 465.0, 566.75]
 DATA_COLUMN_BOUNDARIES = [223.0, 416.0, 465.0, 566.75]
@@ -149,7 +149,9 @@ def _load_single_page_section_from_template(file_path: str, section_name: str,
                                            pandas_options=PANDAS_OPTIONS,
                                            java_options=JAVA_OPTIONS,
                                            stream=stream,
-                                           pages=page_nr, **kwargs)[0]
+                                           pages=page_nr,
+                                           silent=True,
+                                           **kwargs)[0]
         return df.to_dict('records')
     except KeyError:
         raise ParserError(f'Statement {Path(file_path).name} does not contain the {section_name} '
@@ -357,6 +359,8 @@ def _get_full_statement_rows(file_path: str) -> Iterator[Iterator[dict]]:
                                   stream=True,
                                   pandas_options=PANDAS_OPTIONS,
                                   java_options=JAVA_OPTIONS,
+                                  silent=True,
+                                  force_subprocess=True,
                                   pages=f'{start_range}-{end_range}'):
             yield (row for row in df.to_dict('records'))
 

--- a/src/kb_parser/parser.py
+++ b/src/kb_parser/parser.py
@@ -17,7 +17,7 @@ MAX_CHUNK_SIZE = 1000
 PANDAS_OPTIONS = {'dtype': str}
 
 # Limit the memory for docker execution / requires JAVA 11
-JAVA_OPTIONS = '-Xmx480m -Xms480m'
+JAVA_OPTIONS = '-Xmx768m -Xms768m'
 
 # DATA_COLUMN_BOUNDARIES = [42.16, 223.0, 416.0, 465.0, 566.75]
 DATA_COLUMN_BOUNDARIES = [223.0, 416.0, 465.0, 566.75]


### PR DESCRIPTION
This pull request introduces changes to improve workflow flexibility, optimize resource usage, and enhance functionality in the `kb_parser` module. The most important updates include modifying branch filters in the GitHub Actions workflow, adjusting memory allocation settings in the `Dockerfile` and `parser.py`, and adding a new `force_subprocess` parameter to specific parsing functions.

### Workflow Updates:
* [`.github/workflows/push.yml`](diffhunk://#diff-f3fc934cf0d89bdf07de358896ff90f1202585df812cf606206d1830a9949811R7): Added support for branches prefixed with `fix/*` in the GitHub Actions workflow. This expands the workflow's applicability to include additional branch naming conventions.

### Resource Optimization:
* [`Dockerfile`](diffhunk://#diff-dd2c0eb6ea5cfc6c4bd4eac30934e2d5746747af48fef6da689e85b752f39557L26-R26): Increased the maximum JVM heap size (`JAVA_OPTS`) from 512MB to 1024MB to better accommodate memory-intensive tasks.
* `src/kb_parser/parser.py`:
  * Reduced `MAX_CHUNK_SIZE` from 1000 to 500 to optimize memory usage during processing.
  * Updated `JAVA_OPTIONS` to increase the maximum heap size to 900MB and adjusted the initial heap size to 512MB for better performance.

### Functional Enhancements:
* `src/kb_parser/parser.py`:
  * Added the `force_subprocess=True` parameter to the `_load_single_page_section_from_template` function to enforce subprocess execution during parsing, improving compatibility in certain environments.
  * Incorporated the `force_subprocess=True` parameter into the `_get_full_statement_rows` function for consistent behavior across multi-page parsing operations.